### PR TITLE
Render GitHub references

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -110,7 +110,7 @@ ipython_config.py
 #   This is especially recommended for binary packages to ensure reproducibility, and is more
 #   commonly ignored for libraries.
 #   https://python-poetry.org/docs/basic-usage/#commit-your-poetrylock-file-to-version-control
-#poetry.lock
+poetry.lock
 
 # pdm
 #   Similar to Pipfile.lock, it is generally recommended to include pdm.lock in version control.
@@ -593,4 +593,4 @@ FodyWeavers.xsd
 
 # End of https://www.toptal.com/developers/gitignore/api/visualstudiocode,visualstudio,python,dotenv,notepadpp
 
-poetry.lock
+gh_cache.json

--- a/ReadMe.MD
+++ b/ReadMe.MD
@@ -11,5 +11,5 @@ Source code of [CSAuto website](https://csauto.vercel.app). ( [CSAuto repo](http
 
 ## TO-DO
 
-- [ ] Parse GitHub references in Changelog
+- [x] Parse GitHub references in Changelog
 - [ ] Use live.py and serverless functions from Vercel

--- a/scripts/github_cl.py
+++ b/scripts/github_cl.py
@@ -1,0 +1,163 @@
+import os
+import json
+
+from httpx import Client
+from loguru import logger
+
+from shared import CSAUTO_GH_REPO, Paths
+
+import typing as t
+
+try:
+    import dotenv
+    dotenv.load_dotenv()
+except ImportError:
+    pass
+
+
+class GHClient:
+    def __init__(self, token: t.Optional[str] = None) -> None:
+        headers = {"X-GitHub-Api-Version": "2022-11-28",
+                   "accept": "application/vnd.github+json"}
+        if token:
+            headers["Authorization"] = "Bearer " + token
+        self.client = Client(headers=headers, follow_redirects=True)
+        self.cache = list()
+        if os.environ.get("CSAUTO_LOAD_GH_CACHE", 0) in ("1", 1):
+            with open(os.path.join(Paths.ROOT_DIR, "gh_cache.json"), mode="r", encoding="utf-8") as f:
+                self.cache.extend(json.load(f))
+        
+    @staticmethod
+    def is_this_default_repo(repo_owner: str, repo: str):
+        return f"{repo_owner}/{repo}" == CSAUTO_GH_REPO
+    
+    def list_issues(self, page: int = 1, per_page: int = 30, repo: t.Optional[str] = None):
+        if repo is None:
+            repo = CSAUTO_GH_REPO
+        logger.trace(f"List issues {repo} (page={page}, per_page={per_page})")
+        resp = self.client.get(f"https://api.github.com/repos/{repo}/issues",
+                               params=dict(page=page, per_page=per_page, state="all"))
+        return resp.json()
+    
+    def get_issue(self, issue_number: int, repo: t.Optional[str]):
+        if repo is None:
+            repo = CSAUTO_GH_REPO
+        logger.trace(f"Get {repo}/issues/{issue_number}")
+        resp = self.client.get(f"https://api.github.com/repos/{repo}/issues/{issue_number}")
+        resp.raise_for_status()
+        res = resp.json()
+        res["_type"] = "issue"
+        self.cache.append(res)
+        return res
+    
+    def list_all_issues(self, repo: t.Optional[str] = None):
+        if repo is None:
+            repo = CSAUTO_GH_REPO
+        logger.trace(f"Get all issues from {repo}")
+        res = list()
+        while "link" in (resp := self.client.get(f"https://api.github.com/repos/{repo}/issues", params=dict(state="all"))).headers:
+            res.extend(resp.json())
+        res.extend(resp.json())
+        return res
+    
+    def list_pulls(self, page: int = 1, per_page: int = 30, repo: t.Optional[str] = None):
+        if repo is None:
+            repo = CSAUTO_GH_REPO
+        logger.trace(f"List PRs {repo} (page={page}, per_page={per_page})")
+        resp = self.client.get(f"https://api.github.com/repos/{repo}/pulls",
+                               params=dict(page=page, per_page=per_page, state="all"))
+        return resp.json()
+    
+    def get_pull(self, pull_number: int, repo: t.Optional[str]):
+        if repo is None:
+            repo = CSAUTO_GH_REPO
+        logger.trace(f"Get {repo}/pulls/{pull_number}")
+        resp = self.client.get(f"https://api.github.com/repos/{repo}/pulls/{pull_number}")
+        resp.raise_for_status()
+        res = resp.json()
+        res["_type"] = "pull"
+        self.cache.append(res)
+        return res
+    
+    def list_all_pulls(self, repo: t.Optional[str] = None):
+        if repo is None:
+            repo = CSAUTO_GH_REPO
+        logger.trace(f"Get all PRs from {repo}")
+        res = list()
+        while "link" in (resp := self.client.get(f"https://api.github.com/repos/{repo}/pulls", params=dict(state="all"))).headers:
+            res.extend(resp.json())
+        res.extend(resp.json())
+        return res
+    
+    def contributors(self, page: int = 1, per_page: int = 30, repo: t.Optional[str] = None):
+        if repo is None:
+            repo = CSAUTO_GH_REPO
+        logger.trace(f"List contributors {repo} (page={page}, per_page={per_page})")
+        resp = self.client.get(f"https://api.github.com/repos/{repo}/contributors",
+                               params=dict(page=page, per_page=per_page))
+        return resp.json()
+    
+    def list_all_contributors(self, repo: t.Optional[str] = None):
+        if repo is None:
+            repo = CSAUTO_GH_REPO
+        logger.trace(f"Get all contributors from {repo}")
+        res = list()
+        while "link" in (resp := self.client.get(f"https://api.github.com/repos/{repo}/contributors")).headers:
+            res.extend(resp.json())
+        res.extend(resp.json())
+        return res
+    
+    def get_user(self, user: str, cached=True):
+        if cached:
+            if res := tuple(filter(lambda x: x["_type"] == "user" and x.get("login") == user, self.cache)):
+                return res[0]
+        logger.trace(f"Get user {user}")
+        resp = self.client.get(f"https://api.github.com/users/{user}")
+        resp.raise_for_status()
+        res = resp.json()
+        res["_type"] = "user"
+        self.cache.append(res)
+    
+    def try_user(self, user: str):
+        try:
+            self.get_user(user)
+        except Exception as e:
+            logger.opt(exception=e).warning(f"Can't find user {user}")
+    
+    def try_index(self, index: int, repo: t.Optional[str] = None):
+        if repo is None:
+            repo = CSAUTO_GH_REPO
+        if repo == CSAUTO_GH_REPO:
+            if res := tuple(filter(lambda x: x["_type"] == "issue" and x.get("number") == index, self.cache)):
+                if "pull_request" not in res[0]:
+                    return res[0]  # Return issue
+                return tuple(filter(lambda x: x["_type"] == "pull" and x.get("number") == index, self.cache))[0]  # Return PR
+        logger.debug(f"Can't find {repo}#{index} in cache. Requesting from API")
+        try:
+            issue = self.get_issue(index, repo=repo)
+        except Exception as e:
+            logger.opt(exception=e).warning(f"Couldn't find {repo}#{index}")
+            return None
+        if "pull_request" in issue:
+            try:
+                pull = self.get_pull(index, repo=repo)
+            except Exception as e:
+                logger.opt(exception=e).warning(f"Couldn't find {repo}#{index}")
+                return None
+            return pull
+        return issue
+    
+    def cache_all(self):
+        issues = self.list_all_issues()
+        self.cache.extend(tuple(map(lambda x: dict(x, **dict(_type="issue")), issues)))
+        pulls = self.list_all_pulls()
+        self.cache.extend(tuple(map(lambda x: dict(x, **dict(_type="pull")), pulls)))
+        contributors = self.list_all_contributors()
+        self.cache.extend(tuple(map(lambda x: dict(x, **dict(_type="user")), contributors)))
+
+
+if __name__ == "__main__":
+    gh = GHClient()
+    gh.cache_all()
+    with open(os.path.join(Paths.ROOT_DIR, "gh_cache.json"), mode="w+", encoding="utf-8") as f:
+        json.dump(gh.cache, f, indent=4)

--- a/scripts/github_md.py
+++ b/scripts/github_md.py
@@ -20,6 +20,9 @@ class GHReferenceRenderer(GHClient):
     def install(self, md: MarkdownIt):
         md.core.ruler.push("GHRefLink_core", self.ref_link_core)
 
+    def __call__(self, *args, **kwargs):
+        return self.install(*args, **kwargs)
+
     def get_data_from_reference(self, ref_match: str | re.Match):
         if isinstance(ref_match, str):
             ref_match = REF_REGEX.match(ref_match)

--- a/scripts/github_md.py
+++ b/scripts/github_md.py
@@ -1,0 +1,146 @@
+import re
+
+from markdown_it import MarkdownIt
+from markdown_it.token import Token
+from markdown_it.rules_core.state_core import StateCore
+from markdown_it.common.utils import arrayReplaceAt, isLinkClose, isLinkOpen
+from loguru import logger
+
+from github_cl import GHClient
+from shared import CSAUTO_GH_REPO
+
+import typing as t
+
+
+REF_REGEX = re.compile(r"(?:(?:https://)?github\.com\/)?(?:(?P<owner>(?:[A-Za-z]|\d|-)+)/)?(?P<repo>(?:[A-Za-z]|\d|-)+)?(?:#|\/(?P<ref_type>issues|pull)\/)(?P<index>\d+)")
+USER_REGEX = re.compile(r"@([a-z0-9](?:-(?=[a-z0-9])|[a-z0-9]){0,38}(?<=[a-z0-9]))", re.IGNORECASE)  # https://stackoverflow.com/a/30281147/20533050
+
+
+class GHReferenceRenderer(GHClient):
+    def install(self, md: MarkdownIt):
+        md.core.ruler.push("GHRefLink_core", self.ref_link_core)
+
+    def get_data_from_reference(self, ref_match: str | re.Match):
+        if isinstance(ref_match, str):
+            ref_match = REF_REGEX.match(ref_match)
+        if ref_match.group("owner") and ref_match.group("repo"):
+            return self.try_index(int(ref_match.group("index")), repo=f"{ref_match.group('owner')}/{ref_match.group('repo')}")
+        else:
+            return self.try_index(int(ref_match.group("index")))
+    
+    def ref_link_core(self, state: StateCore):
+        """Rule for identifying any plain-text references to GitHub users and PRs/Issues"""
+        # sth a-like rules_core/linkify
+        for inline_token in state.tokens:
+            if inline_token.type != "inline":
+                continue
+            tokens = inline_token.children
+            html_link_level = 0
+            i = len(tokens)
+            while i >= 1:
+                i -= 1
+                current_token = tokens[i]
+                # Skip markdown links
+                if current_token.type == "link_close" and current_token.info != "auto" and "github.com" in current_token.attrs.get("href", "None"):
+                    i -= 1
+                    while tokens[i].level != current_token.level and tokens[i].type != "link_open":
+                        i -= 1
+                    continue
+                # Skip html tag links
+                if current_token.type == "html_inline":
+                    if isLinkOpen(current_token.content) and html_link_level > 0:
+                        html_link_level -= 1
+                    if isLinkClose(current_token.content):
+                        html_link_level += 1
+                if html_link_level > 0:
+                    continue
+                # Skipping non-text
+                if current_token.type != "text":
+                    continue
+
+                # USERS
+                
+                text = current_token.content
+                nodes = list()
+                level = current_token.level
+                last_pos = 0
+                for user_match in USER_REGEX.finditer(text):
+                    pos = user_match.span()[0]
+
+                    if pos > last_pos:
+                        token = Token("text", "", 0)
+                        token.content = text[last_pos:pos]
+                        token.level = level
+                        nodes.append(token)
+
+                    token = Token("link_open", "a", 1)
+                    token.attrs = {"href": f"https://github.com/{user_match.group(1)}",
+                                   "data-tooltip": "GitHub profile"}
+                    token.level = level
+                    level += 1
+                    nodes.append(token)
+
+                    token = Token("text", "", 0)
+                    token.content = user_match.group(0)
+                    token.level = level
+                    nodes.append(token)
+
+                    token = Token("link_close", "a", -1)
+                    level -= 1
+                    token.level = level
+                    nodes.append(token)
+
+                    last_pos = user_match.span()[1]
+
+                    if last_pos < len(text):
+                        token = Token("text", "", 0)
+                        token.content = text[last_pos:]
+                        token.level = level
+                        nodes.append(token)
+
+                    tokens = arrayReplaceAt(tokens, i, nodes)
+                    inline_token.children = tokens
+
+                # PR / ISSUES
+
+                last_pos = 0
+                for ref_match in REF_REGEX.finditer(text):
+                    data = self.get_data_from_reference(ref_match)
+                    if not data:
+                        continue
+
+                    pos = ref_match.span()[0]
+
+                    if pos > last_pos:
+                        token = Token("text", "", 0)
+                        token.content = text[last_pos:pos]
+                        token.level = level
+                        nodes.append(token)
+
+                    token = Token("link_open", "a", 1)
+                    token.attrs = {"href": data["html_url"],
+                                   "data-tooltip": ("Pull Request" if data["_type"] == "pull" else "Issue") + f": {data['title']}"}
+                    token.level = level
+                    level += 1
+                    nodes.append(token)
+
+                    token = Token("text", "", 0)
+                    token.content = f"#{data['number']}"
+                    token.level = level
+                    nodes.append(token)
+
+                    token = Token("link_close", "a", -1)
+                    level -= 1
+                    token.level = level
+                    nodes.append(token)
+
+                    last_pos = ref_match.span()[1]
+
+                    if last_pos < len(text):
+                        token = Token("text", "", 0)
+                        token.content = text[last_pos:]
+                        token.level = level
+                        nodes.append(token)
+
+                    tokens = arrayReplaceAt(tokens, i, nodes)
+                    inline_token.children = tokens

--- a/scripts/github_md.py
+++ b/scripts/github_md.py
@@ -40,8 +40,8 @@ class GHReferenceRenderer(GHClient):
             while i >= 1:
                 i -= 1
                 current_token = tokens[i]
-                # Skip markdown links
-                if current_token.type == "link_close" and current_token.info != "auto" and "github.com" in current_token.attrs.get("href", "None"):
+                # Skip markdown and automatically created links
+                if current_token.type == "link_close" and current_token.info != "auto":
                     i -= 1
                     while tokens[i].level != current_token.level and tokens[i].type != "link_open":
                         i -= 1

--- a/scripts/live.py
+++ b/scripts/live.py
@@ -3,6 +3,7 @@ import os
 from fastapi import FastAPI
 from fastapi.responses import HTMLResponse, PlainTextResponse
 from fastapi.staticfiles import StaticFiles
+from loguru import logger
 import uvicorn
 
 from render import Render

--- a/scripts/render.py
+++ b/scripts/render.py
@@ -1,10 +1,35 @@
 from markdown_it import MarkdownIt
+from markdown_it.presets import commonmark
+from markdown_it.utils import PresetType
 from loguru import logger
 from jinja2 import Environment, FileSystemLoader
 
 from shared import LANGUAGES, DEFAULT_LANGUAGE, Paths
+from github_md import GHReferenceRenderer
 from get_data import BaseDataProvider, RawGithubProvider
 
+
+class gfm_like_custom:  # noqa: N801
+    """GitHub Flavoured Markdown (GFM) like.
+
+    This adds the linkify, table and strikethrough components to CommmonMark.
+
+    Note, it lacks task-list items and raw HTML filtering,
+    to meet the the full GFM specification
+    (see https://github.github.com/gfm/#autolinks-extension-).
+    """
+
+    @staticmethod
+    def make() -> PresetType:
+        config = commonmark.make()
+        config["components"]["core"]["rules"].append("GHRefLink_core")
+        config["components"]["core"]["rules"].append("linkify")
+        config["components"]["block"]["rules"].append("table")
+        config["components"]["inline"]["rules"].extend(["strikethrough", "linkify"])
+        config["components"]["inline"]["rules2"].append("strikethrough")
+        config["options"]["linkify"] = True
+        config["options"]["html"] = True
+        return config
 
 
 class Render:
@@ -12,7 +37,9 @@ class Render:
         self.lang = lang
         self.engine = Environment(loader=FileSystemLoader(Paths.TEMPLATES_DIR))
         self.provider: BaseDataProvider = provider_class()
-        self.markdown = MarkdownIt(config="gfm-like")
+        self.markdown = MarkdownIt()
+        GHReferenceRenderer().install(self.markdown)
+        self.markdown.configure(gfm_like_custom.make())
     
     def get_filename(self, name: str):
         # Maybe will be needed in future
@@ -27,3 +54,9 @@ class Render:
         logger.debug(f"Got {len(changelog_md)} changelogs")
         changelog_html = list(map(self.markdown.render, changelog_md))
         return self.engine.get_template(self.get_filename("changelog")).render(active_nav="changelog", changelogs=changelog_html)
+
+
+if __name__ == '__main__':
+    r = Render()
+    r.render_index()
+    r.render_changelog()

--- a/scripts/render.py
+++ b/scripts/render.py
@@ -39,6 +39,7 @@ class Render:
         self.provider: BaseDataProvider = provider_class()
         self.markdown = MarkdownIt()
         self.gh_ref = GHReferenceRenderer()
+        self.gh_ref.cache_all()
         self.markdown.use(self.gh_ref)
         self.markdown.configure(gfm_like_custom.make())
     

--- a/scripts/render.py
+++ b/scripts/render.py
@@ -38,7 +38,8 @@ class Render:
         self.engine = Environment(loader=FileSystemLoader(Paths.TEMPLATES_DIR))
         self.provider: BaseDataProvider = provider_class()
         self.markdown = MarkdownIt()
-        GHReferenceRenderer().install(self.markdown)
+        self.gh_ref = GHReferenceRenderer()
+        self.markdown.use(self.gh_ref)
         self.markdown.configure(gfm_like_custom.make())
     
     def get_filename(self, name: str):

--- a/www/changelog.html
+++ b/www/changelog.html
@@ -113,7 +113,7 @@
 </ul>
 <h2>What's Changed</h2>
 <ul>
-<li>Add FullChangelog and Version + GH Actions by @NoPlagiarism in <a href="https://github.com/MurkyYT/CSAuto/pull/26">https://github.com/MurkyYT/CSAuto/pull/26</a></li>
+<li>Add FullChangelog and Version + GH Actions by <a href="https://github.com/NoPlagiarism" data-tooltip="GitHub profile">@NoPlagiarism</a> in <a href="https://github.com/MurkyYT/CSAuto/pull/26"><a href="https://github.com/MurkyYT/CSAuto/pull/26" data-tooltip="Pull Request: Add FullChangelog and Version + GH Actions">#26</a></a></li>
 </ul>
 
 </article>
@@ -156,8 +156,8 @@
 <li>Changed default intaller location because can't create files in admin protected folders</li>
 <li>Showing a warning message when can't create files in admin protected folders</li>
 <li>DXGICapture library update</li>
-<li>Fix #24</li>
-<li>Fix #25</li>
+<li>Fix <a href="https://github.com/MurkyYT/CSAuto/issues/24" data-tooltip="Issue: [BUG] Discord error logging">#24</a></li>
+<li>Fix <a href="https://github.com/MurkyYT/CSAuto/issues/25" data-tooltip="Issue: [BUG] Screen capture crashes again">#25</a></li>
 </ul>
 
 </article>
@@ -179,7 +179,7 @@
 <ul>
 <li>Discord Rich Presence map image now loads from the web</li>
 <li>Fixed a bug with <a href="https://developer.valvesoftware.com/wiki/Counter-Strike:_Global_Offensive_Game_State_Integration">GSI</a> which happens when GSI doesn't have the player category in it (for some reason?) which crashed the parsing</li>
-<li>Fixes #23</li>
+<li>Fixes <a href="https://github.com/MurkyYT/CSAuto/issues/23" data-tooltip="Issue: Button.json not found problem">#23</a></li>
 </ul>
 
 </article>
@@ -197,7 +197,7 @@
 <article>
     <h3>Version 2.0.1 changelog</h3>
 <ul>
-<li>Fixes #22</li>
+<li>Fixes <a href="https://github.com/MurkyYT/CSAuto/issues/22" data-tooltip="Issue: Screen capture crashes">#22</a></li>
 </ul>
 
 </article>
@@ -220,7 +220,7 @@
 <li><code>--maximized</code> - use to make guiwindow always open maximized</li>
 </ul>
 </li>
-<li>Added new icon to application! (credit @NoPlagiarism)</li>
+<li>Added new icon to application! (credit <a href="https://github.com/NoPlagiarism" data-tooltip="GitHub profile">@NoPlagiarism</a>)</li>
 <li>Not sure if everything works as it should and as it was earlier</li>
 <li>I would like you to send an issue if you encounter any bug or unusual behaviour</li>
 </ul>
@@ -229,12 +229,12 @@
 <h1><em>Have fun playing CS2 and using CSAuto v2 :)</em></h1>
 <h2>What's Changed</h2>
 <ul>
-<li>Merge master and source2 by @MurkyYT in <a href="https://github.com/MurkyYT/CSAuto/pull/3">https://github.com/MurkyYT/CSAuto/pull/3</a></li>
-<li>Design overhall and GUI addition by @MurkyYT in <a href="https://github.com/MurkyYT/CSAuto/pull/15">https://github.com/MurkyYT/CSAuto/pull/15</a></li>
-<li>Add Discord RPC Customization menu by @MurkyYT in <a href="https://github.com/MurkyYT/CSAuto/pull/17">https://github.com/MurkyYT/CSAuto/pull/17</a></li>
-<li>Make GitHub logo vector by @NoPlagiarism in <a href="https://github.com/MurkyYT/CSAuto/pull/19">https://github.com/MurkyYT/CSAuto/pull/19</a></li>
-<li>Redisigned logo by @NoPlagiarism in <a href="https://github.com/MurkyYT/CSAuto/pull/21">https://github.com/MurkyYT/CSAuto/pull/21</a></li>
-<li>Getting CSAuto to work with Counter-Strike 2 by @MurkyYT in <a href="https://github.com/MurkyYT/CSAuto/pull/14">https://github.com/MurkyYT/CSAuto/pull/14</a></li>
+<li>Merge master and source2 by <a href="https://github.com/MurkyYT" data-tooltip="GitHub profile">@MurkyYT</a> in <a href="https://github.com/MurkyYT/CSAuto/pull/3"><a href="https://github.com/MurkyYT/CSAuto/pull/3" data-tooltip="Pull Request: Merge master and source2">#3</a></a></li>
+<li>Design overhall and GUI addition by <a href="https://github.com/MurkyYT" data-tooltip="GitHub profile">@MurkyYT</a> in <a href="https://github.com/MurkyYT/CSAuto/pull/15"><a href="https://github.com/MurkyYT/CSAuto/pull/15" data-tooltip="Pull Request: Design overhall and GUI addition">#15</a></a></li>
+<li>Add Discord RPC Customization menu by <a href="https://github.com/MurkyYT" data-tooltip="GitHub profile">@MurkyYT</a> in <a href="https://github.com/MurkyYT/CSAuto/pull/17"><a href="https://github.com/MurkyYT/CSAuto/pull/17" data-tooltip="Pull Request: Add Discord RPC Customization menu">#17</a></a></li>
+<li>Make GitHub logo vector by <a href="https://github.com/NoPlagiarism" data-tooltip="GitHub profile">@NoPlagiarism</a> in <a href="https://github.com/MurkyYT/CSAuto/pull/19"><a href="https://github.com/MurkyYT/CSAuto/pull/19" data-tooltip="Pull Request: Make GitHub logo vector">#19</a></a></li>
+<li>Redisigned logo by <a href="https://github.com/NoPlagiarism" data-tooltip="GitHub profile">@NoPlagiarism</a> in <a href="https://github.com/MurkyYT/CSAuto/pull/21"><a href="https://github.com/MurkyYT/CSAuto/pull/21" data-tooltip="Pull Request: Redisigned logo">#21</a></a></li>
+<li>Getting CSAuto to work with Counter-Strike 2 by <a href="https://github.com/MurkyYT" data-tooltip="GitHub profile">@MurkyYT</a> in <a href="https://github.com/MurkyYT/CSAuto/pull/14"><a href="https://github.com/MurkyYT/CSAuto/pull/14" data-tooltip="Pull Request: Getting CSAuto to work with Counter-Strike 2">#14</a></a></li>
 </ul>
 
 </article>
@@ -254,7 +254,7 @@
 <ul>
 <li>More fixes with DXGICapture (help)</li>
 <li>Should capture all exceptions now</li>
-<li>Fixed github logo by making it vector (@NoPlagiarism )</li>
+<li>Fixed github logo by making it vector (<a href="https://github.com/NoPlagiarism" data-tooltip="GitHub profile">@NoPlagiarism</a> )</li>
 <li>Added launch options!
 <ul>
 <li><code>--show</code> - use to show guiwindow on startup</li>
@@ -265,7 +265,7 @@
 </ul>
 <h2>What's Changed</h2>
 <ul>
-<li>Make GitHub logo vector by @NoPlagiarism in <a href="https://github.com/MurkyYT/CSAuto/pull/19">https://github.com/MurkyYT/CSAuto/pull/19</a></li>
+<li>Make GitHub logo vector by <a href="https://github.com/NoPlagiarism" data-tooltip="GitHub profile">@NoPlagiarism</a> in <a href="https://github.com/MurkyYT/CSAuto/pull/19"><a href="https://github.com/MurkyYT/CSAuto/pull/19" data-tooltip="Pull Request: Make GitHub logo vector">#19</a></a></li>
 </ul>
 
 </article>
@@ -330,15 +330,15 @@
 <article>
     <h3>Version 1.1.2 changelog</h3>
 <ol>
-<li>Changed how bomb notifications work in telegram (#16 )</li>
+<li>Changed how bomb notifications work in telegram (<a href="https://github.com/MurkyYT/CSAuto/issues/16" data-tooltip="Issue: Change the way how bomb notification sends">#16</a> )</li>
 </ol>
 <ul>
 <li>Telegram bot shows only when bomb is planted without the timer</li>
 </ul>
 <h2>What's Changed</h2>
 <ul>
-<li>VirusTotal detection fixes + new class for api keys by @MurkyYT in <a href="https://github.com/MurkyYT/CSAuto/pull/12">https://github.com/MurkyYT/CSAuto/pull/12</a></li>
-<li>Fix telegram notifications + compilation fix by @MurkyYT in <a href="https://github.com/MurkyYT/CSAuto/pull/13">https://github.com/MurkyYT/CSAuto/pull/13</a></li>
+<li>VirusTotal detection fixes + new class for api keys by <a href="https://github.com/MurkyYT" data-tooltip="GitHub profile">@MurkyYT</a> in <a href="https://github.com/MurkyYT/CSAuto/pull/12"><a href="https://github.com/MurkyYT/CSAuto/pull/12" data-tooltip="Pull Request: VirusTotal detection fixes + new class for api keys">#12</a></a></li>
+<li>Fix telegram notifications + compilation fix by <a href="https://github.com/MurkyYT" data-tooltip="GitHub profile">@MurkyYT</a> in <a href="https://github.com/MurkyYT/CSAuto/pull/13"><a href="https://github.com/MurkyYT/CSAuto/pull/13" data-tooltip="Pull Request: Fix telegram notifications + compilation fix">#13</a></a></li>
 </ul>
 
 </article>
@@ -368,8 +368,8 @@
 </ol>
 <h2>What's Changed</h2>
 <ul>
-<li>Moved all csauto project to a folder by @MurkyYT in <a href="https://github.com/MurkyYT/CSAuto/pull/9">https://github.com/MurkyYT/CSAuto/pull/9</a></li>
-<li>Improvments of application by @MurkyYT in <a href="https://github.com/MurkyYT/CSAuto/pull/10">https://github.com/MurkyYT/CSAuto/pull/10</a></li>
+<li>Moved all csauto project to a folder by <a href="https://github.com/MurkyYT" data-tooltip="GitHub profile">@MurkyYT</a> in <a href="https://github.com/MurkyYT/CSAuto/pull/9"><a href="https://github.com/MurkyYT/CSAuto/pull/9" data-tooltip="Pull Request: Moved all csauto project to a folder">#9</a></a></li>
+<li>Improvments of application by <a href="https://github.com/MurkyYT" data-tooltip="GitHub profile">@MurkyYT</a> in <a href="https://github.com/MurkyYT/CSAuto/pull/10"><a href="https://github.com/MurkyYT/CSAuto/pull/10" data-tooltip="Pull Request: Improvments of application">#10</a></a></li>
 </ul>
 
 </article>
@@ -378,7 +378,7 @@
     <h3>Version 1.0.9 changelog</h3>
 <ol>
 <li>Added languages to the application, available languages right now are: English and Russian.</li>
-<li>Added icon to the installer (thanks @NoPlagiarism)</li>
+<li>Added icon to the installer (thanks <a href="https://github.com/NoPlagiarism" data-tooltip="GitHub profile">@NoPlagiarism</a>)</li>
 <li>There are now <a href="https://github.com/MurkyYT/CSAuto/#contributors">contributors</a> in the README</li>
 <li>Added <a href="https://github.com/MurkyYT/CSAuto/#building-the-app">building instruction</a> to the README</li>
 <li>Added <a href="https://github.com/MurkyYT/CSAuto/blob/master/README_ru.md">russian translation</a> to the README</li>
@@ -386,11 +386,11 @@
 </ol>
 <h2>What's Changed</h2>
 <ul>
-<li>Some ru&amp;en lang fix + &quot;restartneeded&quot; by @NoPlagiarism in <a href="https://github.com/MurkyYT/CSAuto/pull/8">https://github.com/MurkyYT/CSAuto/pull/8</a></li>
+<li>Some ru&amp;en lang fix + &quot;restartneeded&quot; by <a href="https://github.com/NoPlagiarism" data-tooltip="GitHub profile">@NoPlagiarism</a> in <a href="https://github.com/MurkyYT/CSAuto/pull/8"><a href="https://github.com/MurkyYT/CSAuto/pull/8" data-tooltip="Pull Request: Some ru&amp;en lang fix + &quot;restartneeded&quot;">#8</a></a></li>
 </ul>
 <h2>New Contributors</h2>
 <ul>
-<li>@NoPlagiarism made their first contribution in <a href="https://github.com/MurkyYT/CSAuto/pull/8">https://github.com/MurkyYT/CSAuto/pull/8</a></li>
+<li><a href="https://github.com/NoPlagiarism" data-tooltip="GitHub profile">@NoPlagiarism</a> made their first contribution in <a href="https://github.com/MurkyYT/CSAuto/pull/8"><a href="https://github.com/MurkyYT/CSAuto/pull/8" data-tooltip="Pull Request: Some ru&amp;en lang fix + &quot;restartneeded&quot;">#8</a></a></li>
 </ul>
 
 </article>


### PR DESCRIPTION
- Render GH references through [markdown-it-py](https://github.com/executablebooks/markdown-it-py) plugin system.
- Tooltips for PR & Issues with the title on em
- Small GitHub "client" with cache logic added