### PR TITLE
Bump pico-css to v2 + change theme

### DIFF
--- a/ReadMe.MD
+++ b/ReadMe.MD
@@ -63,5 +63,4 @@ poetry shell
 
 ## TO-DO
 
-- [x] Parse GitHub references in Changelog
-- [ ] Use live.py and serverless functions from Vercel
+- [ ] Add support for translations

--- a/ReadMe.MD
+++ b/ReadMe.MD
@@ -6,12 +6,17 @@ Source code of [CSAuto website](https://csauto.vercel.app). ( [CSAuto repo](http
 
 - [jinja](https://jinja.palletsprojects.com) templates
 - [markdown-it-py](https://github.com/executablebooks/markdown-it-py) for rendering FAQ and Changelog from main repo
-- [picocss](https://picocss.com) css framework
+- [picocss](https://picocss.com) as css framework
 - [Vercel](https://vercel.com) for deploy
 - [httpx](https://www.python-httpx.org) as main HTTP client (mainly for GitHub)
 - [loguru](https://github.com/Delgan/loguru) to log
 - Also, [FastAPI](https://fastapi.tiangolo.com) and [Uvicorn](https://www.uvicorn.org) for live debugging
 - [python-dotenv](https://github.com/theskumar/python-dotenv) for reading .env files
+
+### Deserves mention
+
+- [Font Awesome](https://fontawesome.com/) svg icons
+- [Scoop svg logo](https://github.com/ScoopInstaller/Scoop/discussions/5516) by @xmha97
 
 ## Development
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "csauto-web"
-version = "2.0.0"
+version = "2.2.0"
 description = "Script to render CSAuto web"
 authors = ["NoPlagiarism <37241775+NoPlagiarism@users.noreply.github.com>"]
 license = "MIT"

--- a/scripts/github_cl.py
+++ b/scripts/github_cl.py
@@ -108,6 +108,13 @@ class GHClient:
         res.extend(resp.json())
         return res
     
+    def get_latest_release(self, repo: t.Optional[str] = None):
+        if repo is None:
+            repo = CSAUTO_GH_REPO
+        logger.trace(f"Get latest release from {repo}")
+        resp = self.client.get(f"https://api.github.com/repos/{repo}/releases/latest")
+        return resp.json()
+    
     def get_user(self, user: str, cached=True):
         if cached:
             if res := tuple(filter(lambda x: x["_type"] == "user" and x.get("login") == user, self.cache)):

--- a/scripts/github_cl.py
+++ b/scripts/github_cl.py
@@ -25,8 +25,11 @@ class GHClient:
         self.client = Client(headers=headers, follow_redirects=True)
         self.cache = list()
         if CSAUTO_LOAD_GH_CACHE:
-            with open(os.path.join(Paths.ROOT_DIR, "gh_cache.json"), mode="r", encoding="utf-8") as f:
-                self.cache.extend(json.load(f))
+            try:
+                with open(os.path.join(Paths.ROOT_DIR, "gh_cache.json"), mode="r", encoding="utf-8") as f:
+                    self.cache.extend(json.load(f))
+            except FileNotFoundError:
+                logger.warning("gh_cache.json not found")
         
     @staticmethod
     def is_this_default_repo(repo_owner: str, repo: str):

--- a/scripts/render.py
+++ b/scripts/render.py
@@ -58,13 +58,17 @@ class Render:
     
     def render_index(self):
         faq_html = self.markdown.render(self.provider.get_faq(self.lang))
-        return self.engine.get_template(self.get_filename("index")).render(active_nav="home", faq=faq_html, canon_link=self.base_url)
+        latest_version = self.provider.get_version()
+        return self.engine.get_template(self.get_filename("index")).render(active_nav="home", faq=faq_html, canon_link=self.base_url, latest_version=latest_version)
     
     def render_changelog(self):
         changelog_md = self.provider.get_changelog()
         logger.debug(f"Got {len(changelog_md)} changelogs")
         changelog_html = list(map(self.markdown.render, changelog_md))
         return self.engine.get_template(self.get_filename("changelog")).render(active_nav="changelog", changelogs=changelog_html, canon_link=self.base_url.join("/changelog"))
+    
+    def just_render(self, name: str, path: str):
+        return self.engine.get_template(self.get_filename(name)).render(active_nav=name, canon_link=self.base_url.join(path))
 
 
 if __name__ == '__main__':

--- a/templates/base.jinja
+++ b/templates/base.jinja
@@ -87,5 +87,10 @@
     {% endblock %}
     {% block main required %}
     {% endblock %}
+    <footer>
+        <small>
+            This website and CSAuto are not affiliated, endorsed by, or in any way officially connected with <a href="https://www.valvesoftware.com/">Valve</a> and/or <a href="https://www.counter-strike.net/">Counter-Strike</a>
+        </small>
+    </footer>
 </body>
 </html>

--- a/templates/base.jinja
+++ b/templates/base.jinja
@@ -50,7 +50,7 @@
 
     <link rel="icon" type="image/x-icon" href="public/favicon.ico">
     <link rel="stylesheet" href="css/main.css">
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@picocss/pico@1/css/pico.min.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@picocss/pico@2/css/pico.jade.min.css">
 
     <script defer src="/_vercel/insights/script.js"></script>
     {% endblock %}

--- a/templates/index.jinja
+++ b/templates/index.jinja
@@ -8,7 +8,7 @@
                 <a href="https://github.com/MurkyYT/CSAuto/releases"><img alt="Version" src="https://img.shields.io/github/v/release/MurkyYT/CSAuto?logo=github&style=for-the-badge"></a>
                 <a href="https://discord.gg/57ZEVZgm5W"><img alt="Join Discord" src="https://dcbadge.vercel.app/api/server/57ZEVZgm5W"></a>
             </div>
-            <div align="center"><a href="https://github.com/murkyyt/csauto/releases/latest" role="button">Download</a></div>
+            <div align="center"><a href="#downloads" role="button">Download</a>&nbsp<a href="#FAQ" role="button">FAQ</a></div>
         </section>
         <section class="container-fluid FeaturesSection">
             <h1 align="center">Features of CSAuto</h1>
@@ -74,6 +74,50 @@
                         You can use built-in templates to change the presence state/details<br>
                         In addition, you can add one custom button with a custom link
                     </p>
+                </div>
+            </div>
+        </section>
+        <section class="DonwloadsSection container" id="downloads">
+            <div class="downloads grid">
+                <!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.-->
+                <div class="DownloadColumn">
+                    <h4>Binary installers</h4>
+                    <hr>
+                    <h5>Windows</h5>
+                    <a role="button" href="https://github.com/MurkyYT/CSAuto/releases/download/{{latest_version}}/CSAuto_Installer.exe">
+                        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512"><path d="M288 32c0-17.7-14.3-32-32-32s-32 14.3-32 32V274.7l-73.4-73.4c-12.5-12.5-32.8-12.5-45.3 0s-12.5 32.8 0 45.3l128 128c12.5 12.5 32.8 12.5 45.3 0l128-128c12.5-12.5 12.5-32.8 0-45.3s-32.8-12.5-45.3 0L288 274.7V32zM64 352c-35.3 0-64 28.7-64 64v32c0 35.3 28.7 64 64 64H448c35.3 0 64-28.7 64-64V416c0-35.3-28.7-64-64-64H346.5l-45.3 45.3c-25 25-65.5 25-90.5 0L165.5 352H64zm368 56a24 24 0 1 1 0 48 24 24 0 1 1 0-48z"/></svg>
+
+                        Installer (.EXE)</a>
+                    <a role="button" href="https://github.com/MurkyYT/CSAuto/releases/download/{{latest_version}}/CSAuto_Portable.zip">
+                        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 384 512"><path d="M64 0C28.7 0 0 28.7 0 64V448c0 35.3 28.7 64 64 64H320c35.3 0 64-28.7 64-64V160H256c-17.7 0-32-14.3-32-32V0H64zM256 0V128H384L256 0zM96 48c0-8.8 7.2-16 16-16h32c8.8 0 16 7.2 16 16s-7.2 16-16 16H112c-8.8 0-16-7.2-16-16zm0 64c0-8.8 7.2-16 16-16h32c8.8 0 16 7.2 16 16s-7.2 16-16 16H112c-8.8 0-16-7.2-16-16zm0 64c0-8.8 7.2-16 16-16h32c8.8 0 16 7.2 16 16s-7.2 16-16 16H112c-8.8 0-16-7.2-16-16zm-6.3 71.8c3.7-14 16.4-23.8 30.9-23.8h14.8c14.5 0 27.2 9.7 30.9 23.8l23.5 88.2c1.4 5.4 2.1 10.9 2.1 16.4c0 35.2-28.8 63.7-64 63.7s-64-28.5-64-63.7c0-5.5 .7-11.1 2.1-16.4l23.5-88.2zM112 336c-8.8 0-16 7.2-16 16s7.2 16 16 16h32c8.8 0 16-7.2 16-16s-7.2-16-16-16H112z"/></svg>
+
+                        Portable (.ZIP)</a>
+                    <hr>
+                    <h5>Android</h5>
+                    <a role="button" href="https://github.com/MurkyYT/CSAuto/releases/download/{{latest_version}}/CSAuto_Android.apk">
+                        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 576 512"><path d="M420.6 301.9a24 24 0 1 1 24-24 24 24 0 0 1 -24 24m-265.1 0a24 24 0 1 1 24-24 24 24 0 0 1 -24 24m273.7-144.5 47.9-83a10 10 0 1 0 -17.3-10h0l-48.5 84.1a301.3 301.3 0 0 0 -246.6 0L116.2 64.5a10 10 0 1 0 -17.3 10h0l47.9 83C64.5 202.2 8.2 285.6 0 384H576c-8.2-98.5-64.5-181.8-146.9-226.6"/></svg>
+                        
+                        Installer (.APK)</a>
+                    <hr>
+                    <a role="button" href="https://github.com/MurkyYT/CSAuto/releases">
+                        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512"><path d="M75 75L41 41C25.9 25.9 0 36.6 0 57.9V168c0 13.3 10.7 24 24 24H134.1c21.4 0 32.1-25.9 17-41l-30.8-30.8C155 85.5 203 64 256 64c106 0 192 86 192 192s-86 192-192 192c-40.8 0-78.6-12.7-109.7-34.4c-14.5-10.1-34.4-6.6-44.6 7.9s-6.6 34.4 7.9 44.6C151.2 495 201.7 512 256 512c141.4 0 256-114.6 256-256S397.4 0 256 0C185.3 0 121.3 28.7 75 75zm181 53c-13.3 0-24 10.7-24 24V256c0 6.4 2.5 12.5 7 17l72 72c9.4 9.4 24.6 9.4 33.9 0s9.4-24.6 0-33.9l-65-65V152c0-13.3-10.7-24-24-24z"/></svg>
+                        
+                        All versions</a>
+                </div>
+                <div class="DownloadColumn">
+                    <h4>App Managers</h4>
+                    <hr>
+                    <h5>Windows</h5>
+                    <div role="group" id="scoop">
+                        <a role="button" href="https://scoop.sh/#/apps?q=csauto">
+                            <!-- Scoop svg logo was made by https://github.com/xmha97 https://github.com/ScoopInstaller/Scoop/discussions/5516 -->
+                            <svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" viewBox="0 0 317.3 342.6" xml:space="preserve"><path d="M158.6,142.9c50.4,0.4,100.2,4.4,150,12c5.8,0.9,9.7,6.6,8.5,12.1c-15.5,71.3-72,175.6-158.4,175.6 	S15.8,238.4,0.2,167c-1.2-5.6,2.7-11.2,8.4-12.1C58.5,147.2,108.3,143.2,158.6,142.9z" fill="#6D6875"/><path d="M317,167c-0.5,2.5-1.1,5-1.8,7.6c-11.5,11.2-77.2,19.8-156.6,19.8S13.5,185.8,2,174.6c-0.7-2.6-1.2-5.1-1.8-7.6 	c-1.2-5.6,2.7-11.2,8.4-12.1c49.8-7.6,99.6-11.6,150-12c50.4,0.4,100.2,4.4,150,12C314.4,155.8,318.3,161.4,317,167z" fill="#7D7983"/> <ellipse cx="158.6" cy="165.9" rx="148.4" ry="21.5" fill="#44404B"/> <g> 	<circle cx="157.7" cy="76.5" r="76.5" fill="#F07B96"/> 	<path d="M173.7,147.8c0,1.2,0,2.3-0.1,3.5c-0.6,13.1-4.5,25.4-10.9,36c-1.4,0-2.7,0-4.1,0c-1.5,0-3.1,0-4.6,0 		c-56.1-0.2-104.4-5-128.1-11.8c-3.3-8.6-5.2-17.9-5.2-27.7c0-36.8,26-67.5,60.6-74.8c5.1-1.1,10.5-1.7,15.9-1.7 		c25.3,0,47.8,12.3,61.8,31.3c2.3,3.1,4.4,6.5,6.2,10c2,3.9,3.7,7.9,5,12.1C172.5,132,173.7,139.8,173.7,147.8z" fill="#E4E87C"/> 	<path fill="#775DA6" d="M296.5,148.7c0,9.4-1.7,18.3-4.8,26.6c-23.7,6.9-72.4,11.8-129,12c-1.4,0-2.7,0-4.1,0c-1.5,0-3.1,0-4.6,0 		c-6.2-10.5-9.9-22.7-10.4-35.7c0-1-0.1-2-0.1-2.9c0-17.3,5.7-33.3,15.4-46.1c14-18.5,36.1-30.4,61.1-30.4c4.8,0,9.5,0.5,14.1,1.3 		C269.7,80.1,296.5,111.3,296.5,148.7z"/> 	<path d="M155.2,140.7c-0.6-10.2,3.8-17.8,8.3-25.3c6.4-10.7,13.3-21.1,24-28.1c3.3-2.2,6.8-4,11.1-3.3 		c2.6,0.4,5.5,0.1,6.4,3.3c1,3.6,0.3,7.2-2.5,9.6c-6.9,5.9-14.1,11.4-21,17.2c-8.4,7-16.2,14.5-20.1,25.2c-0.2,0.6-0.5,1.1-0.8,1.7 		c-1.1,2-2.1,5.2-4.4,4.7C153.8,145,155.8,141.7,155.2,140.7z" fill="#D5C2E2"/><path d="M31.7,131.6c1.2-7.3,3.5-14.2,8.9-20.1c5.3-5.8,9.7-12.3,15.7-17.5c6.3-5.4,12.6-11,21.3-12.4 		c4.2-0.7,7.5,0.3,9.3,4.5c1.5,3.6-0.2,5.5-2.7,8.2c-5.3,5.5-12.3,8.1-18.4,12c-11.3,7.2-21.6,15.2-28.3,27.1c-1,1.8-1.8,4.8-4.4,3.9C30.7,136.6,32.3,133.7,31.7,131.6z" fill="#FAFAE8"/><path d="M92.8,60.6c1.4-7.9,5.4-15.2,10.5-21.8c7.2-9.4,15.1-18.2,25.5-24.5c4.5-2.7,9.1-3.5,14.1-3.4c2.8,0,4.5,2.1,5.4,4.4c1.1,2.6,0.1,5.2-1.7,7.3c-3.8,4.4-9.1,6.9-14,9.6c-14.1,7.7-27,16.5-35.1,30.9c-0.7,1.3-1.9,3.2-3.4,2.6C92.1,65.1,93.4,62.8,92.8,60.6z" fill="#FAC8D0"/></g><path d="M28.3,194.3c6,1.1,10.9,2.9,15.7,2.7c8.8-0.3,11.1,4.4,12.8,11.9c3.8,16.2,9.1,32,15.3,47.5c5.4,13.4,12,26.2,18.1,39.2c0.7,1.5,2.2,2.7,0.2,4.2c-1.9,1.5-3.6,0.4-4.8-0.9c-4.8-5-9.8-9.9-14.1-15.4c-9.4-12.1-17.5-24.9-24.5-38.5c-7.8-15.3-14.6-31-18.8-47.7C28.1,196.2,27,194.6,28.3,194.3z" fill="#D8D4DC"/></svg>
+
+                            Scoop</a>
+                        <code>
+                            scoop bucket add games<br>scoop install csauto
+                        </code>
+                    </div>
                 </div>
             </div>
         </section>

--- a/www/changelog.html
+++ b/www/changelog.html
@@ -559,5 +559,10 @@ After that you should be good to go.</li>
 
 </main>
 
+    <footer>
+        <small>
+            This website and CSAuto are not affiliated, endorsed by, or in any way officially connected with <a href="https://www.valvesoftware.com/">Valve</a> and/or <a href="https://www.counter-strike.net/">Counter-Strike</a>
+        </small>
+    </footer>
 </body>
 </html>

--- a/www/changelog.html
+++ b/www/changelog.html
@@ -50,7 +50,7 @@
 
     <link rel="icon" type="image/x-icon" href="public/favicon.ico">
     <link rel="stylesheet" href="css/main.css">
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@picocss/pico@1/css/pico.min.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@picocss/pico@2/css/pico.jade.min.css">
 
     <script defer src="/_vercel/insights/script.js"></script>
     

--- a/www/css/main.css
+++ b/www/css/main.css
@@ -1,15 +1,18 @@
 [data-theme=light], :root:not([data-theme=dark]) {
-    --bg-secondary: #CBFCE1;
+    --bg-secondary: #CBFCE1;  /* pico-jade-50 */
+    --downloads-column-bg: #70FCBA; /* pico-jade-100 */
 }
 
 @media only screen and (prefers-color-scheme: dark) {
     :root:not([data-theme]) {
-        --bg-secondary: #202838;
+        --bg-secondary: #202838;  /* pico-background-color */
+        --downloads-column-bg: #00452B;  /* pico-jade-750 */
     }
 }
 
 [data-theme=dark] {
-    --bg-secondary: #202838;
+    --bg-secondary: #202838;  /* pico-background-color */
+    --downloads-column-bg: #00452B;  /* pico-jade-750 */
 }
 
 nav {
@@ -150,4 +153,43 @@ dialog footer {
 
 dialog footer p {
     font-size: small;
+}
+
+/* Downloads section */
+
+.downloads {
+    width: 100%;
+    background-color: var(--bg-secondary);
+}
+
+.DownloadColumn {
+    background-color: var(--downloads-column-bg);
+    margin: 5px;
+    padding: 3px;
+    display: grid;
+    align-content: start;
+    gap: 10px;
+}
+
+.DownloadColumn svg {
+    width: 32px;
+    color: #9BCCFD;  /* pico-color-azure-200 */
+}
+
+.DownloadColumn code {
+    width: fit-content;
+}
+
+.downloads div {
+    border-radius: 0.25em;
+}
+
+.DownloadColumn a {
+    width: fit-content;
+    height: fit-content;
+    padding: 10px;
+}
+
+.DownloadColumn hr {
+    margin: 0px;
 }

--- a/www/css/main.css
+++ b/www/css/main.css
@@ -23,6 +23,11 @@ nav {
     z-index: 2;
 }
 
+footer {
+    background-color: var(--bg-secondary);
+    text-align: center;
+}
+
 nav h4 {
     /*lil crutch*/
     @media screen and (max-width: 400px) {

--- a/www/css/main.css
+++ b/www/css/main.css
@@ -1,15 +1,15 @@
 [data-theme=light], :root:not([data-theme=dark]) {
-    --bg-secondary: #C5EEDA;
+    --bg-secondary: #CBFCE1;
 }
 
 @media only screen and (prefers-color-scheme: dark) {
     :root:not([data-theme]) {
-        --bg-secondary: #20282D;
+        --bg-secondary: #202838;
     }
 }
 
 [data-theme=dark] {
-    --bg-secondary: #20282D;
+    --bg-secondary: #202838;
 }
 
 nav {
@@ -32,7 +32,7 @@ html {
 }
 
 main {
-    margin-top: 75px;
+    margin-top: 90px;
 }
 
 /* index.html */
@@ -88,7 +88,6 @@ section.FeaturesSection {
 }
 
 .col-1 video, .col-1 img {
-    padding-right: 3px;
     @media screen and (min-width: 800px) {
         padding: 0px;
     }

--- a/www/index.html
+++ b/www/index.html
@@ -94,7 +94,7 @@
                 <a href="https://github.com/MurkyYT/CSAuto/releases"><img alt="Version" src="https://img.shields.io/github/v/release/MurkyYT/CSAuto?logo=github&style=for-the-badge"></a>
                 <a href="https://discord.gg/57ZEVZgm5W"><img alt="Join Discord" src="https://dcbadge.vercel.app/api/server/57ZEVZgm5W"></a>
             </div>
-            <div align="center"><a href="https://github.com/murkyyt/csauto/releases/latest" role="button">Download</a></div>
+            <div align="center"><a href="#downloads" role="button">Download</a>&nbsp<a href="#FAQ" role="button">FAQ</a></div>
         </section>
         <section class="container-fluid FeaturesSection">
             <h1 align="center">Features of CSAuto</h1>
@@ -160,6 +160,50 @@
                         You can use built-in templates to change the presence state/details<br>
                         In addition, you can add one custom button with a custom link
                     </p>
+                </div>
+            </div>
+        </section>
+        <section class="DonwloadsSection container" id="downloads">
+            <div class="downloads grid">
+                <!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.-->
+                <div class="DownloadColumn">
+                    <h4>Binary installers</h4>
+                    <hr>
+                    <h5>Windows</h5>
+                    <a role="button" href="https://github.com/MurkyYT/CSAuto/releases/download/2.0.9/CSAuto_Installer.exe">
+                        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512"><path d="M288 32c0-17.7-14.3-32-32-32s-32 14.3-32 32V274.7l-73.4-73.4c-12.5-12.5-32.8-12.5-45.3 0s-12.5 32.8 0 45.3l128 128c12.5 12.5 32.8 12.5 45.3 0l128-128c12.5-12.5 12.5-32.8 0-45.3s-32.8-12.5-45.3 0L288 274.7V32zM64 352c-35.3 0-64 28.7-64 64v32c0 35.3 28.7 64 64 64H448c35.3 0 64-28.7 64-64V416c0-35.3-28.7-64-64-64H346.5l-45.3 45.3c-25 25-65.5 25-90.5 0L165.5 352H64zm368 56a24 24 0 1 1 0 48 24 24 0 1 1 0-48z"/></svg>
+
+                        Installer (.EXE)</a>
+                    <a role="button" href="https://github.com/MurkyYT/CSAuto/releases/download/2.0.9/CSAuto_Portable.zip">
+                        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 384 512"><path d="M64 0C28.7 0 0 28.7 0 64V448c0 35.3 28.7 64 64 64H320c35.3 0 64-28.7 64-64V160H256c-17.7 0-32-14.3-32-32V0H64zM256 0V128H384L256 0zM96 48c0-8.8 7.2-16 16-16h32c8.8 0 16 7.2 16 16s-7.2 16-16 16H112c-8.8 0-16-7.2-16-16zm0 64c0-8.8 7.2-16 16-16h32c8.8 0 16 7.2 16 16s-7.2 16-16 16H112c-8.8 0-16-7.2-16-16zm0 64c0-8.8 7.2-16 16-16h32c8.8 0 16 7.2 16 16s-7.2 16-16 16H112c-8.8 0-16-7.2-16-16zm-6.3 71.8c3.7-14 16.4-23.8 30.9-23.8h14.8c14.5 0 27.2 9.7 30.9 23.8l23.5 88.2c1.4 5.4 2.1 10.9 2.1 16.4c0 35.2-28.8 63.7-64 63.7s-64-28.5-64-63.7c0-5.5 .7-11.1 2.1-16.4l23.5-88.2zM112 336c-8.8 0-16 7.2-16 16s7.2 16 16 16h32c8.8 0 16-7.2 16-16s-7.2-16-16-16H112z"/></svg>
+
+                        Portable (.ZIP)</a>
+                    <hr>
+                    <h5>Android</h5>
+                    <a role="button" href="https://github.com/MurkyYT/CSAuto/releases/download/2.0.9/CSAuto_Android.apk">
+                        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 576 512"><path d="M420.6 301.9a24 24 0 1 1 24-24 24 24 0 0 1 -24 24m-265.1 0a24 24 0 1 1 24-24 24 24 0 0 1 -24 24m273.7-144.5 47.9-83a10 10 0 1 0 -17.3-10h0l-48.5 84.1a301.3 301.3 0 0 0 -246.6 0L116.2 64.5a10 10 0 1 0 -17.3 10h0l47.9 83C64.5 202.2 8.2 285.6 0 384H576c-8.2-98.5-64.5-181.8-146.9-226.6"/></svg>
+                        
+                        Installer (.APK)</a>
+                    <hr>
+                    <a role="button" href="https://github.com/MurkyYT/CSAuto/releases">
+                        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512"><path d="M75 75L41 41C25.9 25.9 0 36.6 0 57.9V168c0 13.3 10.7 24 24 24H134.1c21.4 0 32.1-25.9 17-41l-30.8-30.8C155 85.5 203 64 256 64c106 0 192 86 192 192s-86 192-192 192c-40.8 0-78.6-12.7-109.7-34.4c-14.5-10.1-34.4-6.6-44.6 7.9s-6.6 34.4 7.9 44.6C151.2 495 201.7 512 256 512c141.4 0 256-114.6 256-256S397.4 0 256 0C185.3 0 121.3 28.7 75 75zm181 53c-13.3 0-24 10.7-24 24V256c0 6.4 2.5 12.5 7 17l72 72c9.4 9.4 24.6 9.4 33.9 0s9.4-24.6 0-33.9l-65-65V152c0-13.3-10.7-24-24-24z"/></svg>
+                        
+                        All versions</a>
+                </div>
+                <div class="DownloadColumn">
+                    <h4>App Managers</h4>
+                    <hr>
+                    <h5>Windows</h5>
+                    <div role="group" id="scoop">
+                        <a role="button" href="https://scoop.sh/#/apps?q=csauto">
+                            <!-- Scoop svg logo was made by https://github.com/xmha97 https://github.com/ScoopInstaller/Scoop/discussions/5516 -->
+                            <svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" viewBox="0 0 317.3 342.6" xml:space="preserve"><path d="M158.6,142.9c50.4,0.4,100.2,4.4,150,12c5.8,0.9,9.7,6.6,8.5,12.1c-15.5,71.3-72,175.6-158.4,175.6 	S15.8,238.4,0.2,167c-1.2-5.6,2.7-11.2,8.4-12.1C58.5,147.2,108.3,143.2,158.6,142.9z" fill="#6D6875"/><path d="M317,167c-0.5,2.5-1.1,5-1.8,7.6c-11.5,11.2-77.2,19.8-156.6,19.8S13.5,185.8,2,174.6c-0.7-2.6-1.2-5.1-1.8-7.6 	c-1.2-5.6,2.7-11.2,8.4-12.1c49.8-7.6,99.6-11.6,150-12c50.4,0.4,100.2,4.4,150,12C314.4,155.8,318.3,161.4,317,167z" fill="#7D7983"/> <ellipse cx="158.6" cy="165.9" rx="148.4" ry="21.5" fill="#44404B"/> <g> 	<circle cx="157.7" cy="76.5" r="76.5" fill="#F07B96"/> 	<path d="M173.7,147.8c0,1.2,0,2.3-0.1,3.5c-0.6,13.1-4.5,25.4-10.9,36c-1.4,0-2.7,0-4.1,0c-1.5,0-3.1,0-4.6,0 		c-56.1-0.2-104.4-5-128.1-11.8c-3.3-8.6-5.2-17.9-5.2-27.7c0-36.8,26-67.5,60.6-74.8c5.1-1.1,10.5-1.7,15.9-1.7 		c25.3,0,47.8,12.3,61.8,31.3c2.3,3.1,4.4,6.5,6.2,10c2,3.9,3.7,7.9,5,12.1C172.5,132,173.7,139.8,173.7,147.8z" fill="#E4E87C"/> 	<path fill="#775DA6" d="M296.5,148.7c0,9.4-1.7,18.3-4.8,26.6c-23.7,6.9-72.4,11.8-129,12c-1.4,0-2.7,0-4.1,0c-1.5,0-3.1,0-4.6,0 		c-6.2-10.5-9.9-22.7-10.4-35.7c0-1-0.1-2-0.1-2.9c0-17.3,5.7-33.3,15.4-46.1c14-18.5,36.1-30.4,61.1-30.4c4.8,0,9.5,0.5,14.1,1.3 		C269.7,80.1,296.5,111.3,296.5,148.7z"/> 	<path d="M155.2,140.7c-0.6-10.2,3.8-17.8,8.3-25.3c6.4-10.7,13.3-21.1,24-28.1c3.3-2.2,6.8-4,11.1-3.3 		c2.6,0.4,5.5,0.1,6.4,3.3c1,3.6,0.3,7.2-2.5,9.6c-6.9,5.9-14.1,11.4-21,17.2c-8.4,7-16.2,14.5-20.1,25.2c-0.2,0.6-0.5,1.1-0.8,1.7 		c-1.1,2-2.1,5.2-4.4,4.7C153.8,145,155.8,141.7,155.2,140.7z" fill="#D5C2E2"/><path d="M31.7,131.6c1.2-7.3,3.5-14.2,8.9-20.1c5.3-5.8,9.7-12.3,15.7-17.5c6.3-5.4,12.6-11,21.3-12.4 		c4.2-0.7,7.5,0.3,9.3,4.5c1.5,3.6-0.2,5.5-2.7,8.2c-5.3,5.5-12.3,8.1-18.4,12c-11.3,7.2-21.6,15.2-28.3,27.1c-1,1.8-1.8,4.8-4.4,3.9C30.7,136.6,32.3,133.7,31.7,131.6z" fill="#FAFAE8"/><path d="M92.8,60.6c1.4-7.9,5.4-15.2,10.5-21.8c7.2-9.4,15.1-18.2,25.5-24.5c4.5-2.7,9.1-3.5,14.1-3.4c2.8,0,4.5,2.1,5.4,4.4c1.1,2.6,0.1,5.2-1.7,7.3c-3.8,4.4-9.1,6.9-14,9.6c-14.1,7.7-27,16.5-35.1,30.9c-0.7,1.3-1.9,3.2-3.4,2.6C92.1,65.1,93.4,62.8,92.8,60.6z" fill="#FAC8D0"/></g><path d="M28.3,194.3c6,1.1,10.9,2.9,15.7,2.7c8.8-0.3,11.1,4.4,12.8,11.9c3.8,16.2,9.1,32,15.3,47.5c5.4,13.4,12,26.2,18.1,39.2c0.7,1.5,2.2,2.7,0.2,4.2c-1.9,1.5-3.6,0.4-4.8-0.9c-4.8-5-9.8-9.9-14.1-15.4c-9.4-12.1-17.5-24.9-24.5-38.5c-7.8-15.3-14.6-31-18.8-47.7C28.1,196.2,27,194.6,28.3,194.3z" fill="#D8D4DC"/></svg>
+
+                            Scoop</a>
+                        <code>
+                            scoop bucket add games<br>scoop install csauto
+                        </code>
+                    </div>
                 </div>
             </div>
         </section>

--- a/www/index.html
+++ b/www/index.html
@@ -245,5 +245,10 @@
         </section>
     </main>
 
+    <footer>
+        <small>
+            This website and CSAuto are not affiliated, endorsed by, or in any way officially connected with <a href="https://www.valvesoftware.com/">Valve</a> and/or <a href="https://www.counter-strike.net/">Counter-Strike</a>
+        </small>
+    </footer>
 </body>
 </html>

--- a/www/index.html
+++ b/www/index.html
@@ -50,7 +50,7 @@
 
     <link rel="icon" type="image/x-icon" href="public/favicon.ico">
     <link rel="stylesheet" href="css/main.css">
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@picocss/pico@1/css/pico.min.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@picocss/pico@2/css/pico.jade.min.css">
 
     <script defer src="/_vercel/insights/script.js"></script>
     


### PR DESCRIPTION
- [Update Pico CSS to v2](https://picocss.com/docs/v2)
- Change [color](https://picocss.com/docs/colors) theme to Jade (Green)
- Add Downloads section
- Add links to FAQ and Downloads sections
- Add footer with "not affiliated" notice
- README:
   - Update TO-DO
   - Add new "mention" section